### PR TITLE
Update rubocop (fix warnings) and minimum Ruby version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,10 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
+  NewCops: enable
 
 Metrics/BlockLength:
   Exclude:
     - 'spec/*_spec.rb'
-
 
 # Disabled cops.
 
@@ -21,6 +21,9 @@ Metrics/MethodLength:
   Enabled: false
 
 Metrics/PerceivedComplexity:
+  Enabled: false
+
+Style/IfUnlessModifier:
   Enabled: false
 
 # vim: sw=2 sts=2 ts=8 et:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,15 @@ os:
   - linux
 
 rvm:
-  - 2.4
   - 2.5
   - 2.6
+  - 2.7
 
 before_install:
   - gem update --system
   - gem install bundler
 
 after_success: |
-  if [[ "$TRAVIS_RUBY_VERSION" = 2.6 && "$TRAVIS_OS_NAME" = linux ]]; then
+  if [[ "$TRAVIS_RUBY_VERSION" = 2.7 && "$TRAVIS_OS_NAME" = linux ]]; then
     bundle exec rake coveralls:push
   fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 ### Changed
+- Changed minimum supported Ruby version to 2.5
 ### Deprecated
 ### Removed
 ### Fixed

--- a/lib/squoosh.rb
+++ b/lib/squoosh.rb
@@ -204,6 +204,7 @@ module Squoosh
       false
     end
 
+    # rubocop:disable Style/StringConcatenation
     EVENT_HANDLERS_XPATH = (
       # Select all attribute nodes whose names start with "on";
       '//@*[starts-with(name(),"on")]' +
@@ -233,6 +234,7 @@ module Squoosh
           ')' \
       ']'
     ).freeze
+    # rubocop:enable Style/StringConcatenation
     private_constant :EVENT_HANDLERS_XPATH
 
     def uglify(content, options)
@@ -345,7 +347,7 @@ module Squoosh
           # value.gsub!(/&([a-zA-Z0-9]+;|#[0-9]+|#[xX][a-fA-F0-9]+)/, '&amp;\1')
           value = (attr.value || '').gsub('&', '&amp;')
           if value.empty?
-            output << ' ' + name
+            output << " #{name}"
           elsif /[\t\n\f\r "'`=<>]/ !~ value
             last_attr_unquoted = true
             output << " #{name}=#{value}"
@@ -391,13 +393,13 @@ module Squoosh
 
       uri = ns.href
       if uri == Nokogiri::HTML5::XML_NAMESPACE
-        'xml:' + attr.name
+        "xml:#{attr.name}"
       elsif uri == Nokogiri::HTML5::XMLNS_NAMESPACE && attr.name == 'xmlns'
         'xmlns'
       elsif uri == Nokogiri::HTML5::XMLNS_NAMESPACE
-        'xmlns:' + attr.name
+        "xmlns:#{attr.name}"
       elsif uri == Nokogiri::HTML5::XLINK_NAMESPACE
-        'xlink:' + attr.name
+        "xlink:#{attr.name}"
       else
         # :nocov:
         raise 'Unreachable!'

--- a/lib/squoosh/version.rb
+++ b/lib/squoosh/version.rb
@@ -2,5 +2,5 @@
 
 module Squoosh
   # The version of squoosh.
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end

--- a/spec/squoosh_spec.rb
+++ b/spec/squoosh_spec.rb
@@ -365,7 +365,7 @@ describe Squoosh do
         '<colgroup><col></colgroup></table>'
       it html do
         expect(Squoosh.minify_html(DOCTYPE + html, OMIT_TAG_OPTIONS))
-          .to eq(DOCTYPE + '<table><col><colgroup><col></table>')
+          .to eq("#{DOCTYPE}<table><col><colgroup><col></table>")
       end
     end
 
@@ -636,7 +636,7 @@ describe Squoosh do
       html = '<script>x="</scr" + "ipt>"</script>'
       it html do
         expect(Squoosh.minify_html(DOCTYPE + html, JS_OPTIONS))
-          .not_to match(%r{<\/script>.*<\/script>})
+          .not_to match(%r{</script>.*</script>})
       end
     end
 

--- a/squoosh.gemspec
+++ b/squoosh.gemspec
@@ -15,16 +15,16 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.files         = %w[LICENSE.txt README.md] + Dir['lib/**/*.rb']
 
-  # rubocop:disable AlignHash
+  # rubocop:disable Layout/HashAlignment
   spec.metadata      = {
     'bug_tracker_uri' => 'https://github.com/stevecheckoway/squoosh/issues',
     'changelog_uri'   => 'https://github.com/stevecheckoway/squoosh/blob/master/CHANGELOG.md',
     'homepage_uri'    => spec.homepage,
     'source_code_uri' => 'https://github.com/stevecheckoway/squoosh'
   }
-  # rubocop:enable AlignHash
+  # rubocop: enable Layout/HashAlignment
 
-  spec.required_ruby_version = '~> 2.4'
+  spec.required_ruby_version = '~> 2.5'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'coveralls'


### PR DESCRIPTION
Updates the minimum Ruby version to 2.5 as 2.4 is EOL. As this impacts
Rubocop, update that too and fix all the new cops (or ignore the
pointless ones).